### PR TITLE
Add /blog editorial section

### DIFF
--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -1,0 +1,27 @@
+name: Blog Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'content/blog/**.md'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: 'latest'
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ hugo
 hugo_*
 *.tar.gz
 
-content/
+# Content managed by Micro.blog, not git — except editorial blog section
+content/*
+!content/blog/

--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,9 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: false
+tags: []
+category: ""
+summary: ""
+---
+

--- a/content/blog/2026-05-23-three-signals-from-november.md
+++ b/content/blog/2026-05-23-three-signals-from-november.md
@@ -1,0 +1,39 @@
+---
+title: "Three Signals from November: What the Bulletins Don't Say"
+date: 2026-05-23T10:00:00-05:00
+draft: false
+tags: [magento, adobe-commerce, cve, attack-analysis]
+category: "Attack Analysis"
+summary: "The November 2025 bulletin wave included a CVSS 9.1 session takeover, a stored XSS in Magento-lts, and an active Xurum webshell campaign. Read together, they describe something the individual advisories don't."
+---
+
+Three items from the November 2025 bulletin queue, taken individually, look like routine security hygiene. Together they tell a different story.
+
+## The Setup: Xurum Is Still Running Playbooks from 2022
+
+The [Xurum webshell campaign](https://www.akamai.com/blog/security-research/new-sophisticated-magento-campaign-xurum-webshell) that Akamai documented isn't new technique — it targets a known Magento vulnerability and deploys a sophisticated webshell that fingerprints server environment, exfiltrates payment data, and provides persistent shell access. What's notable is that the campaign is *still running*, which means:
+
+1. A meaningful percentage of Magento installs are still unpatched against a well-documented attack chain.
+2. The attacker tooling has matured — Xurum has environment-awareness that older skimmer campaigns lacked.
+
+The practical read for commerce ops teams: if you're running a Magento instance and haven't validated your patching posture against Akamai's published indicators, do that before reading the rest of this.
+
+## The Risk That Patch Notes Don't Quantify: CVE-2025-54236
+
+CVSS 9.1. Adobe Commerce. No user interaction required. Session takeover.
+
+The [APSB25-88 advisory](https://helpx.adobe.com/security/products/magento/apsb25-88.html) covers an improper input validation vulnerability affecting Adobe Commerce through 2.4.8-p2 and back to 2.4.4-p15. What the advisory doesn't foreground: in a multi-store environment where admin sessions are long-lived (common in managed service deployments), "session takeover" means an attacker who can reach your admin panel URL has a path to full platform control without needing to know a single credential.
+
+The patch is available. The gap is the deployment window. A vulnerability that requires no user interaction closes fast in the wild once PoC code circulates — and for a CVSS 9.1 Adobe Commerce advisory, that window is short. If you're on any affected version and your deployment pipeline adds days of testing overhead before applying security patches, that's the thing worth fixing.
+
+## The Sleeper: CVE-2025-64174 and Admin DB Access Assumptions
+
+The [Magento-lts stored XSS](https://github.com/OpenMage/magento-lts/security/advisories/GHSA-qv78-c8hc-438r) (fixed in 20.16.0) requires an admin with direct database access or control over the admin notification feed source. That sounds narrow. It isn't.
+
+In practice, multi-vendor commerce deployments frequently involve third-party integrations that touch the database directly — ETL pipelines, ERP connectors, PIM syncs. Any of those that write to notification tables or translation strings without sanitizing output are an injection vector that bypasses the application layer entirely. The "requires admin DB access" framing in the CVE undersells the real-world exposure surface.
+
+## The Pattern
+
+All three of these point at the same underlying gap: Commerce platform security posture is often evaluated at the application layer (patches applied, WAF rules updated) while the actual attack surface extends further — into long-lived sessions, admin-adjacent integrations, and deployment lag. The bulletins report what's been patched. The editorial job here is flagging what that means for how you run the platform.
+
+That's what this blog is for.

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Blog"
+description: "Editorial coverage of the security landscape for Adobe Commerce and Magento — the context, correlation, and preemptive takes that the automated bulletins cannot provide."
+type: blog
+---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -50,6 +50,7 @@
                 <span class="spectrum-logo-text">Adobe Digest</span>
             </a>
             <nav class="spectrum-nav">
+                <a href="/blog/" class="spectrum-nav-link">Blog</a>
                 <a href="/archive/" class="spectrum-nav-link">Archive</a>
                 <a href="/bulletins/feed.xml" class="spectrum-nav-link">RSS</a>
                 <a href="https://github.com/doughatcher/adobe-digest" class="spectrum-nav-link" target="_blank" rel="noopener">GitHub</a>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,53 @@
+{{ define "main" }}
+<div class="page-wrapper">
+    <div class="list-header" style="margin-bottom: 2rem;">
+        <h1 class="page-title">Blog</h1>
+        <p class="list-description" style="color: #aaa; margin-top: 0.5rem;">
+            Editorial coverage of the Commerce security landscape — the correlation, context, and preemptive takes the automated bulletins cannot provide.
+        </p>
+    </div>
+
+    <div class="posts-list">
+        {{ $paginator := .Paginate .Pages (.Site.Params.posts_per_page | default 10) }}
+
+        {{ range $paginator.Pages }}
+        <article class="post-preview blog-post-preview" style="border-bottom: 1px solid #3e3e3e; padding-bottom: 1.5rem; margin-bottom: 1.5rem;">
+            {{ if .Params.category }}
+            <span class="blog-category-badge" style="font-size: 0.75rem; color: #eb1000; text-transform: uppercase; letter-spacing: 0.05em;">{{ .Params.category }}</span>
+            {{ end }}
+
+            <h2 class="post-title" style="margin: 0.25rem 0 0.5rem;">
+                <a href="{{ .Permalink }}" style="color: #f5f5f5; text-decoration: none;">{{ .Title }}</a>
+            </h2>
+
+            <p style="color: #aaa; margin-bottom: 0.75rem;">{{ .Summary | truncate 240 }}</p>
+
+            <div style="display: flex; justify-content: space-between; align-items: center;">
+                <div class="post-meta" style="color: #666; font-size: 0.875rem;">
+                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "January 2, 2006" }}</time>
+                    · {{ .ReadingTime }} min read
+                </div>
+                <a href="{{ .Permalink }}" style="color: #eb1000; font-size: 0.875rem;">Read →</a>
+            </div>
+        </article>
+        {{ else }}
+        <p style="color: #666;">No posts yet — check back soon.</p>
+        {{ end }}
+
+        {{ if gt $paginator.TotalPages 1 }}
+        <nav class="pagination" style="display: flex; gap: 1rem; margin-top: 2rem;">
+            {{ if $paginator.HasPrev }}
+            <a href="{{ $paginator.Prev.URL }}" style="color: #eb1000;">← Newer</a>
+            {{ end }}
+            {{ if $paginator.HasNext }}
+            <a href="{{ $paginator.Next.URL }}" style="color: #eb1000;">Older →</a>
+            {{ end }}
+        </nav>
+        {{ end }}
+    </div>
+
+    <p style="margin-top: 2rem; color: #666; font-size: 0.875rem;">
+        Follow via <a href="/blog/feed.xml" style="color: #eb1000;">RSS</a> or subscribe on <a href="https://micro.blog/hatcher" style="color: #eb1000;">Micro.blog</a>.
+    </p>
+</div>
+{{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,0 +1,50 @@
+{{ define "main" }}
+<div class="page-wrapper">
+    <nav class="breadcrumb">
+        <a href="/">Home</a>
+        <span class="breadcrumb-separator">/</span>
+        <a href="/blog/">Blog</a>
+        <span class="breadcrumb-separator">/</span>
+        <span class="current">{{ .Title }}</span>
+    </nav>
+
+    <article class="content-card blog-post-single" style="margin-top: 2rem;">
+        <header class="page-header">
+            {{ if .Params.category }}
+            <span class="blog-category-badge">{{ .Params.category }}</span>
+            {{ end }}
+            <h1 class="page-title">{{ .Title }}</h1>
+            <div class="page-meta">
+                <div class="meta-item">
+                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "January 2, 2006" }}</time>
+                </div>
+                <div class="meta-item">{{ .ReadingTime }} min read</div>
+            </div>
+        </header>
+
+        <div class="content-wrapper e-content">
+            {{ .Content }}
+        </div>
+
+        {{ if .Params.tags }}
+        <footer class="tags-section" style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #3e3e3e;">
+            <div class="tags-container">
+                {{ range .Params.tags }}
+                <a href="{{ "/tags/" | relURL }}{{ . | urlize }}" class="tag p-category">#{{ . }}</a>
+                {{ end }}
+            </div>
+        </footer>
+        {{ end }}
+    </article>
+
+    <nav class="blog-post-nav" style="margin-top: 2rem; display: flex; gap: 1rem; justify-content: space-between;">
+        {{ if .NextInSection }}
+        <a href="{{ .NextInSection.Permalink }}" style="color: #eb1000;">← {{ .NextInSection.Title }}</a>
+        {{ end }}
+        <a href="{{ "/blog/" | relURL }}" style="color: #999;">← All posts</a>
+        {{ if .PrevInSection }}
+        <a href="{{ .PrevInSection.Permalink }}" style="color: #eb1000;">{{ .PrevInSection.Title }} →</a>
+        {{ end }}
+    </nav>
+</div>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -756,6 +756,7 @@
                 <span class="spectrum-logo-text">Adobe Digest</span>
             </a>
             <nav class="spectrum-nav">
+                <a href="/blog/" class="spectrum-nav-link">Blog</a>
                 <a href="/archive/" class="spectrum-nav-link">Archive</a>
                 <a href="/bulletins/feed.xml" class="spectrum-nav-link">RSS</a>
                 <a href="https://github.com/doughatcher/adobe-digest" class="spectrum-nav-link" target="_blank" rel="noopener">GitHub</a>
@@ -950,6 +951,31 @@
                         <div style="color: #eb1000; font-weight: 700; font-size: 0.875rem; margin-top: 0.25rem;">6 Hours</div>
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <!-- Blog Callout -->
+        <section class="section" style="margin-top: 2rem;">
+            <div class="section-header">
+                <h2 class="section-title">From the Blog</h2>
+                <a href="/blog/" class="section-action">All Posts →</a>
+            </div>
+            <div style="background: #2c2c2c; border: 1px solid #3e3e3e; border-radius: 8px; padding: 1.5rem;">
+                <p style="color: #aaa; margin-bottom: 1rem; font-size: 0.9375rem;">
+                    Editorial analysis of the Commerce security landscape — the correlation, context, and preemptive takes the automated bulletins cannot provide.
+                </p>
+                {{ $blogPages := where .Site.RegularPages "Section" "blog" }}
+                {{ range first 3 $blogPages.ByDate.Reverse }}
+                <div style="border-top: 1px solid #3e3e3e; padding: 1rem 0;">
+                    <a href="{{ .Permalink }}" style="color: #f5f5f5; font-weight: 600; text-decoration: none; display: block; margin-bottom: 0.25rem;">{{ .Title }}</a>
+                    <p style="color: #888; font-size: 0.875rem; margin: 0;">{{ .Summary | truncate 160 }}</p>
+                    <div style="margin-top: 0.5rem; font-size: 0.8125rem; color: #666;">
+                        <time>{{ .Date.Format "January 2, 2006" }}</time> · {{ .ReadingTime }} min read
+                    </div>
+                </div>
+                {{ else }}
+                <p style="color: #666;">First post coming soon.</p>
+                {{ end }}
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Adds `/blog` Hugo section for editorial content, separate from the auto-scraped bulletin stream
- Blog posts publish via `/blog/feed.xml`; micro.blog subscribes to this feed independently from the root bulletin feed (mirrors doughatcher.com pattern)
- Inaugural post: "Three Signals from November" synthesizes Xurum campaign + CVE-2025-54236 + CVE-2025-64174

## Changes
- `content/blog/_index.md` — section root
- `layouts/blog/single.html` + `list.html` — adapted from doughatcher.com layouts
- `archetypes/blog.md` — correct frontmatter for new editorial posts
- `content/blog/2026-05-23-three-signals-from-november.md` — inaugural post
- Blog link added to nav in `baseof.html` and `index.html`
- Homepage blog callout section showing latest 3 posts
- `.github/workflows/blog-publish.yml` — triggers deploy on `content/blog/**` push
- `.gitignore`: `content/*` + `!content/blog/` (mirrors doughatcher.com)

## Test plan
- [ ] `/blog/` list page renders
- [ ] `/blog/feed.xml` valid RSS
- [ ] Blog nav link on all pages
- [ ] Blog callout section on homepage
- [ ] Inaugural post single page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)