### PR TITLE
Add /blog editorial section

### DIFF
--- a/.github/workflows/blog-publish.yml
+++ b/.github/workflows/blog-publish.yml
@@ -1,0 +1,27 @@
+name: Blog Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'content/blog/**.md'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: 'latest'
+
+      - name: Build
+        run: hugo --minify
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
 .hugo_build.lock
 public/
 .DS_Store
+._*
 .env
+.env.*
+!.env.example
+.session-cookie
+*.pem
+*.key
 __pycache__/
 *.pyc
 *.pyo

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 .hugo_build.lock
 public/
 .DS_Store
-._*
 .env
-.session-cookie
 __pycache__/
 *.pyc
 *.pyo
@@ -16,11 +14,6 @@ hugo
 hugo_*
 *.tar.gz
 
-# Content and data (managed by Micro.blog, not git)
-content/
-!content/products/
-!content/archive/
-data/
-
-# Backup archives
-backups/
+# Content managed by Micro.blog, not git — except editorial blog section
+content/*
+!content/blog/

--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,9 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+draft: false
+tags: []
+category: ""
+summary: ""
+---
+

--- a/config.json
+++ b/config.json
@@ -91,6 +91,11 @@
       "renderer": {
         "unsafe": true
       }
+    },
+    "tableOfContents": {
+      "startLevel": 2,
+      "endLevel": 3,
+      "ordered": false
     }
   },
   "enableRobotsTXT": true,

--- a/content/blog/2025-11-26-three-signals-from-november.md
+++ b/content/blog/2025-11-26-three-signals-from-november.md
@@ -2,9 +2,20 @@
 title: "Three Signals from November: What the Bulletins Don't Say"
 date: 2025-11-26T09:00:00-05:00
 draft: false
+author: doug-hatcher
 tags: [magento, adobe-commerce, cve, attack-analysis]
 category: "Attack Analysis"
 summary: "The November 2025 bulletin wave included a CVSS 9.1 session takeover, a stored XSS in Magento-lts, and an active Xurum webshell campaign. Read together, they describe something the individual advisories don't."
+related:
+  - title: "SessionReaper — unauthenticated RCE in Magento & Adobe Commerce (CVE-2025-54236)"
+    url: https://experiencedigest.org/2025/09/08/000000.html
+    date: "September 8, 2025"
+  - title: "Xurum: new Magento campaign discovered"
+    url: https://experiencedigest.org/2025/11/09/xurum-new-magento-campaign-discovered.html
+    date: "November 9, 2025"
+  - title: "CVE-2025-64174 — OpenMage stored XSS"
+    url: https://experiencedigest.org/2025/11/12/cve.html
+    date: "November 12, 2025"
 ---
 
 Three items from the November 2025 bulletin queue, taken individually, look like routine security hygiene. Together they tell a different story.

--- a/content/blog/2025-11-26-three-signals-from-november.md
+++ b/content/blog/2025-11-26-three-signals-from-november.md
@@ -1,6 +1,6 @@
 ---
 title: "Three Signals from November: What the Bulletins Don't Say"
-date: 2026-05-23T10:00:00-05:00
+date: 2025-11-26T09:00:00-05:00
 draft: false
 tags: [magento, adobe-commerce, cve, attack-analysis]
 category: "Attack Analysis"

--- a/content/blog/2026-05-23-composer-perforce-command-injection.md
+++ b/content/blog/2026-05-23-composer-perforce-command-injection.md
@@ -2,6 +2,7 @@
 title: "The Perforce Driver You Never Knew You Had: Composer CVE-2026-40261 and CVE-2026-40176"
 date: 2026-05-23T10:00:00-05:00
 draft: false
+author: doug-hatcher
 tags: [composer, php, supply-chain, cve, magento, adobe-commerce, dependency-management]
 category: "Attack Analysis"
 summary: "Two command injection vulnerabilities in Composer's Perforce driver are exploitable even if you've never touched Perforce. For Magento shops running dev dependencies from source, CVE-2026-40261 is a supply-chain exposure hiding behind a feature most teams don't know is active."

--- a/content/blog/2026-05-23-composer-perforce-command-injection.md
+++ b/content/blog/2026-05-23-composer-perforce-command-injection.md
@@ -1,0 +1,47 @@
+---
+title: "The Perforce Driver You Never Knew You Had: Composer CVE-2026-40261 and CVE-2026-40176"
+date: 2026-05-23T10:00:00-05:00
+draft: false
+tags: [composer, php, supply-chain, cve, magento, adobe-commerce, dependency-management]
+category: "Attack Analysis"
+summary: "Two command injection vulnerabilities in Composer's Perforce driver are exploitable even if you've never touched Perforce. For Magento shops running dev dependencies from source, CVE-2026-40261 is a supply-chain exposure hiding behind a feature most teams don't know is active."
+---
+
+Update Composer to 2.9.6 or 2.2.27 LTS now. If that sentence is enough, you're done. If you want to understand why this one is worth a closer look, keep reading.
+
+## The Perforce Driver Is Loaded Whether You Use It or Not
+
+[CVE-2026-40261](https://github.com/composer/composer/security/advisories/GHSA-gqw4-4w2p-838q) and [CVE-2026-40176](https://github.com/composer/composer/security/advisories/GHSA-wg36-wvj6-r67p) are both in Composer's Perforce VCS driver - the code that handles repositories declared as perforce type in a composer.json. Neither requires Perforce to be installed. Both allow arbitrary command execution in the context of whatever runs composer install or composer update.
+
+That's the part the advisory buries in the third paragraph. Most Magento shops have never configured a Perforce repository and have no intention of doing so. That doesn't matter. The vulnerable code path loads regardless, and an attacker-controlled composer.json or package metadata can reach it.
+
+## Two Different Attack Surfaces
+
+CVE-2026-40176 requires the attacker to control the composer.json you're actually running - the root manifest. The injected values are Perforce connection parameters (port, user, client) that get interpolated into shell commands without escaping. This is the local-project risk: if you're running Composer commands on a project from an untrusted source, this fires.
+
+CVE-2026-40261 is the wider problem. It affects the syncCodeBase() method, which handles a source reference parameter that can come from *package metadata* - not just the root composer.json. That means any Composer repository, including a compromised or malicious third-party repository, can serve package metadata that exploits this. You don't have to touch the root manifest. You just have to install or update a dependency from source.
+
+The trigger condition: installing dev-prefixed versions (anything before 1.0.0, or packages with dev- prefix) defaults to --prefer-source in Composer. Commerce agencies running Magento module development pipelines almost certainly have some dev-constraint packages in their dependency tree.
+
+## What This Means for a Magento and Commerce Pipeline
+
+Enterprise commerce platforms run layered dependency graphs. The core is typically Magento/Adobe Commerce, which comes from the Magento Composer repository. Third-party modules come from a mix of Packagist, private repositories, and occasionally vendor-managed repos. Development workflows - module builds, staging deploys, CI pipelines - regularly operate with dev- constraints to pull HEAD on in-development extensions.
+
+In that environment, CVE-2026-40261 is not hypothetical. Any point in the supply chain where package metadata can be influenced - a compromised private repo, a package repository serving malicious metadata, a CI secret that got rotated too late - becomes a command injection entry point into your build environment. The build environment has access to credentials, cloud provider tokens, and staging infrastructure that production doesn't expose directly.
+
+The patch notes say there's no evidence of exploitation prior to publication. That's the standard disclosure language and it's worth taking at face value. It also doesn't change the update calculus.
+
+## Packagist and Private Packagist Already Moved
+
+Packagist.org disabled Perforce source metadata on April 10, 2026 as a precaution. Private Packagist did the same. If your dependencies come exclusively from these sources and you're not running --prefer-source against anything that reaches Perforce metadata, your exposure was already mitigated at the registry layer.
+
+If you run Private Packagist Self-Hosted, the new release is dropping now - and you should scan your installation using the verification command the release announcement documents before relying on the registry-level mitigation.
+
+## The Practical Calls
+
+1. Run composer.phar self-update on every machine and CI runner that executes Composer commands. This includes local dev environments - dev machines are a vector, not just pipelines.
+2. If you can't update immediately, --prefer-dist in your installs eliminates the CVE-2026-40261 exposure by avoiding the source-fetch path. It's a workaround, not a fix.
+3. For CVE-2026-40176: review any composer.json files you run Composer commands against and aren't fully trust-anchored. If your dev workflow clones external projects and runs composer install on them without inspection, that's a habit worth fixing regardless of this CVE.
+4. Audit your private Composer repositories for Perforce-type source declarations. These should not exist in commerce dependency graphs. If they do, understand why.
+
+This is a straightforward dependency update with a clear fix. The reason it's worth editorial attention is the "doesn't affect Perforce users" misread - the relevant audience here is every team running a PHP/Composer-based build pipeline, which in the commerce world is essentially everyone.

--- a/content/blog/2026-05-23-three-signals-from-november.md
+++ b/content/blog/2026-05-23-three-signals-from-november.md
@@ -1,0 +1,39 @@
+---
+title: "Three Signals from November: What the Bulletins Don't Say"
+date: 2026-05-23T10:00:00-05:00
+draft: false
+tags: [magento, adobe-commerce, cve, attack-analysis]
+category: "Attack Analysis"
+summary: "The November 2025 bulletin wave included a CVSS 9.1 session takeover, a stored XSS in Magento-lts, and an active Xurum webshell campaign. Read together, they describe something the individual advisories don't."
+---
+
+Three items from the November 2025 bulletin queue, taken individually, look like routine security hygiene. Together they tell a different story.
+
+## The Setup: Xurum Is Still Running Playbooks from 2022
+
+The [Xurum webshell campaign](https://www.akamai.com/blog/security-research/new-sophisticated-magento-campaign-xurum-webshell) that Akamai documented isn't new technique — it targets a known Magento vulnerability and deploys a sophisticated webshell that fingerprints server environment, exfiltrates payment data, and provides persistent shell access. What's notable is that the campaign is *still running*, which means:
+
+1. A meaningful percentage of Magento installs are still unpatched against a well-documented attack chain.
+2. The attacker tooling has matured — Xurum has environment-awareness that older skimmer campaigns lacked.
+
+The practical read for commerce ops teams: if you're running a Magento instance and haven't validated your patching posture against Akamai's published indicators, do that before reading the rest of this.
+
+## The Risk That Patch Notes Don't Quantify: CVE-2025-54236
+
+CVSS 9.1. Adobe Commerce. No user interaction required. Session takeover.
+
+The [APSB25-88 advisory](https://helpx.adobe.com/security/products/magento/apsb25-88.html) covers an improper input validation vulnerability affecting Adobe Commerce through 2.4.8-p2 and back to 2.4.4-p15. What the advisory doesn't foreground: in a multi-store environment where admin sessions are long-lived (common in managed service deployments), "session takeover" means an attacker who can reach your admin panel URL has a path to full platform control without needing to know a single credential.
+
+The patch is available. The gap is the deployment window. A vulnerability that requires no user interaction closes fast in the wild once PoC code circulates — and for a CVSS 9.1 Adobe Commerce advisory, that window is short. If you're on any affected version and your deployment pipeline adds days of testing overhead before applying security patches, that's the thing worth fixing.
+
+## The Sleeper: CVE-2025-64174 and Admin DB Access Assumptions
+
+The [Magento-lts stored XSS](https://github.com/OpenMage/magento-lts/security/advisories/GHSA-qv78-c8hc-438r) (fixed in 20.16.0) requires an admin with direct database access or control over the admin notification feed source. That sounds narrow. It isn't.
+
+In practice, multi-vendor commerce deployments frequently involve third-party integrations that touch the database directly — ETL pipelines, ERP connectors, PIM syncs. Any of those that write to notification tables or translation strings without sanitizing output are an injection vector that bypasses the application layer entirely. The "requires admin DB access" framing in the CVE undersells the real-world exposure surface.
+
+## The Pattern
+
+All three of these point at the same underlying gap: Commerce platform security posture is often evaluated at the application layer (patches applied, WAF rules updated) while the actual attack surface extends further — into long-lived sessions, admin-adjacent integrations, and deployment lag. The bulletins report what's been patched. The editorial job here is flagging what that means for how you run the platform.
+
+That's what this blog is for.

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Blog"
+description: "Editorial coverage of the security landscape for Adobe Commerce and Magento — the context, correlation, and preemptive takes that the automated bulletins cannot provide."
+type: blog
+---

--- a/data/authors/doug-hatcher.yaml
+++ b/data/authors/doug-hatcher.yaml
@@ -1,0 +1,11 @@
+# One YAML file per contributor. The filename (slug) is what posts reference
+# via `author: <slug>` (single) or `authors: [<slug>, <slug>]` (multi).
+#
+# Required: name
+# Optional: title, url, avatar, bio
+
+name: Doug Hatcher
+title: Enterprise Architect at Blue Acorn iCI
+url: https://doughatcher.com
+# avatar: /images/authors/doug-hatcher.jpg
+# bio: Short one-or-two-sentence bio shown under the title.

--- a/justfile
+++ b/justfile
@@ -104,6 +104,16 @@ backup-download:
 backup-extract ZIP_FILE:
     python3 .github/deploy/microblog_backup.py --extract-only {{ZIP_FILE}}
 
+# Download the latest content export ZIP from the most recent GitHub release
+release-download:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    mkdir -p backups
+    echo "Fetching latest release from doughatcher/experience-digest..."
+    gh release download --repo doughatcher/experience-digest --pattern "*.zip" --dir backups --clobber
+    echo "Downloaded to backups/:"
+    ls -lh backups/*.zip | tail -5
+
 # Validate session cookie
 validate:
     python3 .github/deploy/microblog_deploy.py --validate-only

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -48,6 +48,7 @@
                 <span class="xd-logo-text">Experience Digest</span>
             </a>
             <nav class="xd-nav">
+                <a href="/blog/" class="xd-nav-link">Blog</a>
                 <a href="/archive/" class="xd-nav-link">Archive</a>
                 <a href="https://experiencedigest.org/feed.json" class="xd-nav-link">RSS</a>
                 <a href="https://github.com/doughatcher/experience-digest" class="xd-nav-link" target="_blank" rel="noopener">GitHub</a>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,13 +12,29 @@
     <title>{{ $title }}</title>
     <meta name="description" content="{{ if .IsHome }}An independent community digest tracking security bulletins, CVEs, and research for Adobe Commerce and Experience Manager. Not affiliated with Adobe.{{ else }}{{ .Summary | truncate 155 }}{{ end }}">
     <meta name="author" content="Doug Hatcher">
+    {{ $homeDescription := "An independent community digest tracking security bulletins, CVEs, and research for Adobe Commerce and Experience Manager. Not affiliated with Adobe." }}
+    {{ $description := "" }}
+    {{ if .IsHome }}
+        {{ $description = $homeDescription }}
+    {{ else if .Params.description }}
+        {{ $description = .Params.description }}
+    {{ else if .Description }}
+        {{ $description = .Description }}
+    {{ else }}
+        {{ $description = .Content | plainify | truncate 280 }}
+    {{ end }}
+    {{ $ogImage := "/android-chrome-512x512.png" | absURL }}
     <meta property="og:type" content="{{ if .IsHome }}website{{ else }}article{{ end }}">
     <meta property="og:site_name" content="Experience Digest — Independent Community Resource">
     <meta property="og:title" content="{{ $title }}">
-    <meta property="og:description" content="{{ if .IsHome }}An independent community digest tracking security bulletins, CVEs, and research for Adobe Commerce and Experience Manager. Not affiliated with Adobe.{{ else }}{{ .Summary | truncate 155 }}{{ end }}">
+    <meta property="og:description" content="{{ $description }}">
+    <meta property="og:url" content="{{ .Permalink }}">
+    <meta property="og:image" content="{{ $ogImage }}">
+    <meta property="og:image:alt" content="Experience Digest">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="{{ $title }}">
-    <meta name="twitter:description" content="{{ if .IsHome }}An independent community digest. Not affiliated with Adobe.{{ else }}{{ .Summary | truncate 100 }}{{ end }}">
+    <meta name="twitter:description" content="{{ $description | truncate 200 }}">
+    <meta name="twitter:image" content="{{ $ogImage }}">
     
     <!-- Micro.blog Discovery & IndieWeb -->
     {{ partial "microblog_head.html" . }}
@@ -41,9 +57,9 @@
         <div class="xd-header-container">
             <a href="/" class="xd-logo">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path fill="#f97316" d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
+                    <path fill="#14b8a6" d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
                     <path fill="#0f0f0f" d="M12 3.19l7 3.11v5.7c0 4.52-2.98 8.69-7 9.93-4.02-1.24-7-5.41-7-9.93V6.3l7-3.11z"/>
-                    <path fill="#f97316" d="M12 7v10m-5-5h10" stroke="#f97316" stroke-width="1.5" stroke-linecap="round"/>
+                    <path fill="#14b8a6" d="M12 7v10m-5-5h10" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/>
                 </svg>
                 <span class="xd-logo-text">Experience Digest</span>
             </a>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -44,7 +44,9 @@
         </div>
         {{ end }}
     </article>
-    
+
+    {{ partial "social-share.html" . }}
+
     <div class="action-group">
         {{ if or .NextInSection .PrevInSection }}
             {{ if .PrevInSection }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,59 @@
+{{ define "main" }}
+<div class="page-wrapper">
+    <div class="page-header" style="margin-bottom: 2rem;">
+        <h1 class="page-title">Blog</h1>
+        <p style="color: #aaa; margin-top: 0.5rem;">
+            Editorial coverage of the Commerce security landscape — the correlation, context, and preemptive takes the automated bulletins cannot provide.
+        </p>
+    </div>
+
+    <div class="posts-list">
+        {{ $paginator := .Paginate .Pages (.Site.Params.posts_per_page | default 10) }}
+
+        {{ range $paginator.Pages }}
+        <article class="content-card" style="margin-bottom: 1.5rem;">
+            {{ if .Params.category }}
+            <span style="font-size: 0.75rem; color: #f97316; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;">{{ .Params.category }}</span>
+            {{ end }}
+
+            <h2 class="page-title" style="font-size: 1.25rem; margin: 0.25rem 0 0.5rem;">
+                <a href="{{ .Permalink }}" style="color: #f5f5f5; text-decoration: none;">{{ .Title }}</a>
+            </h2>
+
+            <p style="color: #aaa; margin-bottom: 0.75rem; font-size: 0.9375rem;">{{ .Summary | truncate 240 }}</p>
+
+            <div class="page-meta">
+                <div class="meta-item">
+                    <span class="meta-icon">📅</span>
+                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "January 2, 2006" }}</time>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-icon">⏱</span>
+                    {{ .ReadingTime }} min read
+                </div>
+                <a href="{{ .Permalink }}" style="margin-left: auto; color: #f97316; font-size: 0.875rem; text-decoration: none;">Read →</a>
+            </div>
+        </article>
+        {{ else }}
+        <div class="content-card">
+            <p style="color: #666;">No posts yet — check back soon.</p>
+        </div>
+        {{ end }}
+
+        {{ if gt $paginator.TotalPages 1 }}
+        <div class="action-group" style="margin-top: 1.5rem;">
+            {{ if $paginator.HasPrev }}
+            <a href="{{ $paginator.Prev.URL }}" class="spectrum-btn spectrum-btn-secondary">← Newer</a>
+            {{ end }}
+            {{ if $paginator.HasNext }}
+            <a href="{{ $paginator.Next.URL }}" class="spectrum-btn spectrum-btn-secondary">Older →</a>
+            {{ end }}
+        </div>
+        {{ end }}
+    </div>
+
+    <p style="margin-top: 2rem; color: #666; font-size: 0.875rem;">
+        Follow via <a href="/blog/feed.xml" style="color: #f97316;">RSS</a> or on <a href="https://micro.blog/experiencedigest" style="color: #f97316;">Micro.blog</a>.
+    </p>
+</div>
+{{ end }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -13,7 +13,7 @@
         {{ range $paginator.Pages }}
         <article class="content-card" style="margin-bottom: 1.5rem;">
             {{ if .Params.category }}
-            <span style="font-size: 0.75rem; color: #f97316; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;">{{ .Params.category }}</span>
+            <span style="font-size: 0.75rem; color: #14b8a6; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;">{{ .Params.category }}</span>
             {{ end }}
 
             <h2 class="page-title" style="font-size: 1.25rem; margin: 0.25rem 0 0.5rem;">
@@ -31,7 +31,7 @@
                     <span class="meta-icon">⏱</span>
                     {{ .ReadingTime }} min read
                 </div>
-                <a href="{{ .Permalink }}" style="margin-left: auto; color: #f97316; font-size: 0.875rem; text-decoration: none;">Read →</a>
+                <a href="{{ .Permalink }}" style="margin-left: auto; color: #14b8a6; font-size: 0.875rem; text-decoration: none;">Read →</a>
             </div>
         </article>
         {{ else }}
@@ -53,7 +53,7 @@
     </div>
 
     <p style="margin-top: 2rem; color: #666; font-size: 0.875rem;">
-        Follow via <a href="/blog/feed.xml" style="color: #f97316;">RSS</a> or on <a href="https://micro.blog/experiencedigest" style="color: #f97316;">Micro.blog</a>.
+        Follow via <a href="/blog/feed.xml" style="color: #14b8a6;">RSS</a> or on <a href="https://micro.blog/experiencedigest" style="color: #14b8a6;">Micro.blog</a>.
     </p>
 </div>
 {{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -8,49 +8,57 @@
         <span class="current">{{ .Title }}</span>
     </nav>
 
-    <article class="content-card" style="margin-top: 2rem;">
-        <header class="page-header">
-            {{ if .Params.category }}
-            <div class="meta-item" style="margin-bottom: 0.5rem;">
-                <span style="font-size: 0.75rem; color: #f97316; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;">{{ .Params.category }}</span>
-            </div>
-            {{ end }}
-            <h1 class="page-title">{{ .Title }}</h1>
-            <div class="page-meta">
-                <div class="meta-item">
-                    <span class="meta-icon">📅</span>
-                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "January 2, 2006" }}</time>
-                </div>
-                <div class="meta-item">
-                    <span class="meta-icon">⏱</span>
-                    {{ .ReadingTime }} min read
-                </div>
-            </div>
-        </header>
+    <div class="blog-layout">
+        <div class="blog-main">
+            <article class="content-card" style="margin-top: 2rem;">
+                <header class="page-header">
+                    {{ if .Params.category }}
+                    <div class="meta-item" style="margin-bottom: 0.5rem;">
+                        <span style="font-size: 0.75rem; color: #14b8a6; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;">{{ .Params.category }}</span>
+                    </div>
+                    {{ end }}
+                    <h1 class="page-title">{{ .Title }}</h1>
+                    <div class="page-meta">
+                        <div class="meta-item">
+                            <span class="meta-icon">📅</span>
+                            <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "January 2, 2006" }}</time>
+                        </div>
+                        <div class="meta-item">
+                            <span class="meta-icon">⏱</span>
+                            {{ .ReadingTime }} min read
+                        </div>
+                    </div>
+                </header>
 
-        <div class="content-wrapper e-content">
-            {{ .Content }}
-        </div>
+                <div class="content-wrapper e-content">
+                    {{ .Content }}
+                </div>
 
-        {{ if .Params.tags }}
-        <div class="tags-section" style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #3e3e3e;">
-            <div class="tags-container">
-                {{ range .Params.tags }}
-                <a href="{{ "/tags/" | relURL }}{{ . | urlize }}" class="tag p-category">{{ . }}</a>
+                {{ if .Params.tags }}
+                <div class="tags-section" style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #3e3e3e;">
+                    <div class="tags-container">
+                        {{ range .Params.tags }}
+                        <a href="{{ "/tags/" | relURL }}{{ . | urlize }}" class="tag p-category">{{ . }}</a>
+                        {{ end }}
+                    </div>
+                </div>
+                {{ end }}
+            </article>
+
+            {{ partial "social-share.html" . }}
+
+            <div class="action-group" style="margin-top: 1.5rem;">
+                {{ if .NextInSection }}
+                <a href="{{ .NextInSection.Permalink }}" class="spectrum-btn spectrum-btn-secondary">← {{ .NextInSection.Title | truncate 40 }}</a>
+                {{ end }}
+                <a href="{{ "/blog/" | relURL }}" class="spectrum-btn spectrum-btn-secondary">← All Posts</a>
+                {{ if .PrevInSection }}
+                <a href="{{ .PrevInSection.Permalink }}" class="spectrum-btn spectrum-btn-secondary">{{ .PrevInSection.Title | truncate 40 }} →</a>
                 {{ end }}
             </div>
         </div>
-        {{ end }}
-    </article>
 
-    <div class="action-group" style="margin-top: 1.5rem;">
-        {{ if .NextInSection }}
-        <a href="{{ .NextInSection.Permalink }}" class="spectrum-btn spectrum-btn-secondary">← {{ .NextInSection.Title | truncate 40 }}</a>
-        {{ end }}
-        <a href="{{ "/blog/" | relURL }}" class="spectrum-btn spectrum-btn-secondary">← All Posts</a>
-        {{ if .PrevInSection }}
-        <a href="{{ .PrevInSection.Permalink }}" class="spectrum-btn spectrum-btn-secondary">{{ .PrevInSection.Title | truncate 40 }} →</a>
-        {{ end }}
+        {{ partial "blog-sidebar.html" . }}
     </div>
 </div>
 {{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,0 +1,56 @@
+{{ define "main" }}
+<div class="page-wrapper">
+    <nav class="breadcrumb">
+        <a href="/">Home</a>
+        <span class="breadcrumb-separator">/</span>
+        <a href="/blog/">Blog</a>
+        <span class="breadcrumb-separator">/</span>
+        <span class="current">{{ .Title }}</span>
+    </nav>
+
+    <article class="content-card" style="margin-top: 2rem;">
+        <header class="page-header">
+            {{ if .Params.category }}
+            <div class="meta-item" style="margin-bottom: 0.5rem;">
+                <span style="font-size: 0.75rem; color: #f97316; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600;">{{ .Params.category }}</span>
+            </div>
+            {{ end }}
+            <h1 class="page-title">{{ .Title }}</h1>
+            <div class="page-meta">
+                <div class="meta-item">
+                    <span class="meta-icon">📅</span>
+                    <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">{{ .Date.Format "January 2, 2006" }}</time>
+                </div>
+                <div class="meta-item">
+                    <span class="meta-icon">⏱</span>
+                    {{ .ReadingTime }} min read
+                </div>
+            </div>
+        </header>
+
+        <div class="content-wrapper e-content">
+            {{ .Content }}
+        </div>
+
+        {{ if .Params.tags }}
+        <div class="tags-section" style="margin-top: 2rem; padding-top: 1.5rem; border-top: 1px solid #3e3e3e;">
+            <div class="tags-container">
+                {{ range .Params.tags }}
+                <a href="{{ "/tags/" | relURL }}{{ . | urlize }}" class="tag p-category">{{ . }}</a>
+                {{ end }}
+            </div>
+        </div>
+        {{ end }}
+    </article>
+
+    <div class="action-group" style="margin-top: 1.5rem;">
+        {{ if .NextInSection }}
+        <a href="{{ .NextInSection.Permalink }}" class="spectrum-btn spectrum-btn-secondary">← {{ .NextInSection.Title | truncate 40 }}</a>
+        {{ end }}
+        <a href="{{ "/blog/" | relURL }}" class="spectrum-btn spectrum-btn-secondary">← All Posts</a>
+        {{ if .PrevInSection }}
+        <a href="{{ .PrevInSection.Permalink }}" class="spectrum-btn spectrum-btn-secondary">{{ .PrevInSection.Title | truncate 40 }} →</a>
+        {{ end }}
+    </div>
+</div>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -70,7 +70,7 @@
         .xd-logo svg {
             width: 32px;
             height: 32px;
-            fill: #f97316;
+            fill: #14b8a6;
         }
         
         .xd-logo-text {
@@ -118,10 +118,10 @@
         .hero-eyebrow {
             display: inline-block;
             padding: 0.375rem 0.875rem;
-            border: 1px solid #f97316;
+            border: 1px solid #14b8a6;
             border-radius: 20px;
             font-size: 0.6875rem;
-            color: #f97316;
+            color: #14b8a6;
             text-transform: uppercase;
             letter-spacing: 0.1em;
             font-weight: 700;
@@ -166,7 +166,7 @@
         }
         
         .stat-badge-number {
-            color: #ea580c;
+            color: #0d9488;
             font-weight: 700;
         }
         
@@ -248,14 +248,14 @@
         }
         
         .sidebar-stat-value.accent {
-            color: #ea580c;
+            color: #0d9488;
         }
         
         /* Ad callout with close button */
         .ad-callout {
             background: linear-gradient(135deg, #1a1a1a 0%, #222 100%);
             border: 1px solid #363636;
-            border-left: 3px solid #ea580c;
+            border-left: 3px solid #0d9488;
             border-radius: 8px;
             padding: 1.25rem;
             position: relative;
@@ -287,7 +287,7 @@
         .ad-title {
             font-size: 0.75rem;
             font-weight: 600;
-            color: #ea580c;
+            color: #0d9488;
             text-transform: uppercase;
             letter-spacing: 0.05em;
             margin-bottom: 0.5rem;
@@ -303,7 +303,7 @@
         .ad-cta {
             display: inline-block;
             padding: 0.5rem 1rem;
-            background: #ea580c;
+            background: #0d9488;
             color: white;
             text-decoration: none;
             border-radius: 4px;
@@ -313,7 +313,7 @@
         }
         
         .ad-cta:hover {
-            background: #c2410c;
+            background: #0f766e;
         }
         
         .section-header {
@@ -455,7 +455,7 @@
         .mini-stat-number {
             font-size: 1.75rem;
             font-weight: 700;
-            color: #ea580c;
+            color: #0d9488;
             margin-bottom: 0.25rem;
         }
         
@@ -554,11 +554,11 @@
         }
         
         .xd-btn-accent {
-            background: #ea580c;
+            background: #0d9488;
         }
         
         .xd-btn-accent:hover {
-            background: #c2410c;
+            background: #0f766e;
         }
         
         /* Footer */
@@ -630,7 +630,7 @@
         
         .subscribe-features span::before {
             content: '✓';
-            color: #ea580c;
+            color: #0d9488;
             margin-right: 0.5rem;
             font-weight: bold;
         }
@@ -772,9 +772,9 @@
         <div class="xd-header-container">
             <a href="/" class="xd-logo">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-                    <path fill="#f97316" d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
+                    <path fill="#14b8a6" d="M12 1L3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5l-9-4z"/>
                     <path fill="#0f0f0f" d="M12 3.19l7 3.11v5.7c0 4.52-2.98 8.69-7 9.93-4.02-1.24-7-5.41-7-9.93V6.3l7-3.11z"/>
-                    <path fill="#f97316" d="M12 7v10m-5-5h10" stroke="#f97316" stroke-width="1.5" stroke-linecap="round"/>
+                    <path fill="#14b8a6" d="M12 7v10m-5-5h10" stroke="#14b8a6" stroke-width="1.5" stroke-linecap="round"/>
                 </svg>
                 <span class="xd-logo-text">Experience Digest</span>
             </a>
@@ -970,7 +970,7 @@
                     </div>
                     <div style="margin-top: 1rem; padding: 0.75rem; background: #222; border: 1px solid #2a2a2a; border-radius: 6px; text-align: center;">
                         <div style="color: #b3b3b3; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.05em;">Updates Every</div>
-                        <div style="color: #ea580c; font-weight: 700; font-size: 0.875rem; margin-top: 0.25rem;">6 Hours</div>
+                        <div style="color: #0d9488; font-weight: 700; font-size: 0.875rem; margin-top: 0.25rem;">6 Hours</div>
                     </div>
                 </div>
             </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -779,6 +779,7 @@
                 <span class="xd-logo-text">Experience Digest</span>
             </a>
             <nav class="xd-nav">
+                <a href="/blog/" class="xd-nav-link">Blog</a>
                 <a href="/archive/" class="xd-nav-link">Archive</a>
                 <a href="https://experiencedigest.org/feed.json" class="xd-nav-link">RSS</a>
                 <a href="https://github.com/doughatcher/experience-digest" class="xd-nav-link" target="_blank" rel="noopener">GitHub</a>
@@ -796,7 +797,7 @@
             {{ $allBulletins := where $allPages "Type" "in" (slice "post" "posts") }}
             {{ if eq (len $allBulletins) 0 }}
                 {{ $allBulletins = where $allPages ".Title" "!=" "" }}
-                {{ $allBulletins = where $allBulletins ".Title" "match" "APSB" }}
+                {{ $allBulletins = where $allBulletins ".Title" "like" "APSB" }}
             {{ end }}
             <div class="stat-badges">
                 <div class="stat-badge">
@@ -972,6 +973,31 @@
                         <div style="color: #ea580c; font-weight: 700; font-size: 0.875rem; margin-top: 0.25rem;">6 Hours</div>
                     </div>
                 </div>
+            </div>
+        </section>
+
+        <!-- Blog Callout -->
+        <section class="section" style="margin-top: 2rem;">
+            <div class="section-header">
+                <h2 class="section-title">From the Blog</h2>
+                <a href="/blog/" class="section-action">All Posts →</a>
+            </div>
+            <div style="background: #2c2c2c; border: 1px solid #3e3e3e; border-radius: 8px; padding: 1.5rem;">
+                <p style="color: #aaa; margin-bottom: 1rem; font-size: 0.9375rem;">
+                    Editorial analysis of the Commerce security landscape — the correlation, context, and preemptive takes the automated bulletins cannot provide.
+                </p>
+                {{ $blogPages := where .Site.RegularPages "Section" "blog" }}
+                {{ range first 3 $blogPages.ByDate.Reverse }}
+                <div style="border-top: 1px solid #3e3e3e; padding: 1rem 0;">
+                    <a href="{{ .Permalink }}" style="color: #f5f5f5; font-weight: 600; text-decoration: none; display: block; margin-bottom: 0.25rem;">{{ .Title }}</a>
+                    <p style="color: #888; font-size: 0.875rem; margin: 0;">{{ .Summary | truncate 160 }}</p>
+                    <div style="margin-top: 0.5rem; font-size: 0.8125rem; color: #666;">
+                        <time>{{ .Date.Format "January 2, 2006" }}</time> · {{ .ReadingTime }} min read
+                    </div>
+                </div>
+                {{ else }}
+                <p style="color: #666;">First post coming soon.</p>
+                {{ end }}
             </div>
         </section>
 

--- a/layouts/partials/blog-sidebar.html
+++ b/layouts/partials/blog-sidebar.html
@@ -1,0 +1,70 @@
+{{/* Resolve author slugs from frontmatter — supports `author: slug` or `authors: [slug, slug]` */}}
+{{ $authorSlugs := slice }}
+{{ with .Params.author }}
+    {{ if reflect.IsSlice . }}
+        {{ $authorSlugs = . }}
+    {{ else }}
+        {{ $authorSlugs = $authorSlugs | append . }}
+    {{ end }}
+{{ end }}
+{{ with .Params.authors }}{{ $authorSlugs = $authorSlugs | append . }}{{ end }}
+
+{{ $toc := .TableOfContents }}
+{{ $hasToc := gt (len $toc) 50 }}
+{{ $related := .Params.related }}
+
+{{ if or $authorSlugs $hasToc $related }}
+<aside class="blog-sidebar">
+
+    {{ if $authorSlugs }}
+    <div class="blog-sidebar-block blog-author-block">
+        <h3 class="blog-sidebar-title">{{ if gt (len $authorSlugs) 1 }}Authors{{ else }}Author{{ end }}</h3>
+        {{ range $authorSlugs }}
+            {{ $a := index $.Site.Data.authors . }}
+            {{ if $a }}
+            <div class="blog-author h-card">
+                {{ with $a.avatar }}
+                <img class="blog-author-avatar u-photo" src="{{ . }}" alt="{{ $a.name }}">
+                {{ else }}
+                <div class="blog-author-avatar blog-author-avatar-fallback" aria-hidden="true">{{ substr $a.name 0 1 }}</div>
+                {{ end }}
+                <div class="blog-author-text">
+                    {{ if $a.url }}
+                    <a class="blog-author-name p-name u-url" href="{{ $a.url }}" rel="author">{{ $a.name }}</a>
+                    {{ else }}
+                    <span class="blog-author-name p-name">{{ $a.name }}</span>
+                    {{ end }}
+                    {{ with $a.title }}<div class="blog-author-title p-job-title">{{ . }}</div>{{ end }}
+                    {{ with $a.bio }}<p class="blog-author-bio p-note">{{ . }}</p>{{ end }}
+                </div>
+            </div>
+            {{ end }}
+        {{ end }}
+    </div>
+    {{ end }}
+
+    {{ if $hasToc }}
+    <div class="blog-sidebar-block">
+        <h3 class="blog-sidebar-title">On this page</h3>
+        <div class="blog-toc">
+            {{ $toc | safeHTML }}
+        </div>
+    </div>
+    {{ end }}
+
+    {{ if $related }}
+    <div class="blog-sidebar-block">
+        <h3 class="blog-sidebar-title">Related coverage</h3>
+        <ul class="blog-related-list">
+            {{ range $related }}
+            <li>
+                <a href="{{ .url }}"{{ if not (hasPrefix .url "/") }} target="_blank" rel="noopener"{{ end }}>{{ .title }}</a>
+                {{ with .date }}<span class="blog-related-date">{{ . }}</span>{{ end }}
+            </li>
+            {{ end }}
+        </ul>
+    </div>
+    {{ end }}
+
+</aside>
+{{ end }}

--- a/layouts/partials/social-share.html
+++ b/layouts/partials/social-share.html
@@ -1,0 +1,132 @@
+{{/* Social share buttons for posts.
+     URL composition pattern: build the full URL with `printf` and `urlquery` for
+     components, then wrap with `safeURL` so Hugo's contextual escaping inside
+     href="…" doesn't URL-encode our percent signs a second time. */}}
+{{ $url := .Permalink }}
+{{ $title := .Title }}
+{{ $summary := .Summary | plainify | truncate 200 }}
+{{ $eUrl := $url | urlquery }}
+{{ $eTitle := $title | urlquery }}
+{{ $eBskyText := printf "%s %s" $title $url | urlquery }}
+{{ $eEmailBody := printf "%s\n\n%s" $summary $url | urlquery }}
+{{ $linkedinHref := printf "https://www.linkedin.com/sharing/share-offsite/?url=%s" $eUrl | safeURL }}
+{{ $xHref := printf "https://twitter.com/intent/tweet?url=%s&text=%s" $eUrl $eTitle | safeURL }}
+{{ $facebookHref := printf "https://www.facebook.com/sharer/sharer.php?u=%s" $eUrl | safeURL }}
+{{ $bskyHref := printf "https://bsky.app/intent/compose?text=%s" $eBskyText | safeURL }}
+{{ $redditHref := printf "https://www.reddit.com/submit?url=%s&title=%s" $eUrl $eTitle | safeURL }}
+{{ $hnHref := printf "https://news.ycombinator.com/submitlink?u=%s&t=%s" $eUrl $eTitle | safeURL }}
+{{ $mailHref := printf "mailto:?subject=%s&body=%s" $eTitle $eEmailBody | safeURL }}
+
+<div class="social-share" aria-label="Share this article">
+    <span class="social-share-label">Share:</span>
+    <a class="social-share-btn social-share-linkedin"
+       href="{{ $linkedinHref }}"
+       target="_blank" rel="noopener noreferrer"
+       aria-label="Share on LinkedIn"
+       title="Share on LinkedIn">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.852 3.37-1.852 3.601 0 4.267 2.37 4.267 5.455v6.288zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.063 2.063 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
+        </svg>
+        <span class="social-share-name">LinkedIn</span>
+    </a>
+    <a class="social-share-btn social-share-x"
+       href="{{ $xHref }}"
+       target="_blank" rel="noopener noreferrer"
+       aria-label="Share on X"
+       title="Share on X (Twitter)">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+        </svg>
+        <span class="social-share-name">X</span>
+    </a>
+    <a class="social-share-btn social-share-facebook"
+       href="{{ $facebookHref }}"
+       target="_blank" rel="noopener noreferrer"
+       aria-label="Share on Facebook"
+       title="Share on Facebook">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/>
+        </svg>
+        <span class="social-share-name">Facebook</span>
+    </a>
+    <a class="social-share-btn social-share-bluesky"
+       href="{{ $bskyHref }}"
+       target="_blank" rel="noopener noreferrer"
+       aria-label="Share on Bluesky"
+       title="Share on Bluesky">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 10.8c-1.087-2.114-4.046-6.053-6.798-7.995C2.566.944 1.561 1.266.902 1.565.139 1.908 0 3.08 0 3.768c0 .69.378 5.65.624 6.479.815 2.736 3.713 3.66 6.383 3.364.136-.02.275-.039.415-.056-.138.022-.276.04-.415.056-3.912.58-7.387 2.005-2.83 7.078 5.013 5.19 6.87-1.113 7.823-4.308.953 3.195 2.05 9.271 7.733 4.308 4.267-4.308 1.172-6.498-2.74-7.078a8.741 8.741 0 01-.415-.056c.14.017.279.036.415.056 2.67.297 5.568-.628 6.383-3.364.246-.828.624-5.79.624-6.478 0-.69-.139-1.861-.902-2.206-.659-.298-1.664-.62-4.3 1.24C16.046 4.748 13.087 8.687 12 10.8z"/>
+        </svg>
+        <span class="social-share-name">Bluesky</span>
+    </a>
+    <a class="social-share-btn social-share-reddit"
+       href="{{ $redditHref }}"
+       target="_blank" rel="noopener noreferrer"
+       aria-label="Share on Reddit"
+       title="Share on Reddit">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 01-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 01.042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 014.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 01.14-.197.35.35 0 01.238-.042l2.906.617a1.214 1.214 0 011.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 00-.231.094.33.33 0 000 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 00.029-.463.33.33 0 00-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 00-.232-.095z"/>
+        </svg>
+        <span class="social-share-name">Reddit</span>
+    </a>
+    <a class="social-share-btn social-share-hackernews"
+       href="{{ $hnHref }}"
+       target="_blank" rel="noopener noreferrer"
+       aria-label="Share on Hacker News"
+       title="Share on Hacker News">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M0 24V0h24v24H0zM6.951 5.896l4.112 7.708v5.064h1.583v-4.972l4.148-7.799h-1.749l-2.457 4.875c-.372.745-.688 1.434-.688 1.434s-.297-.708-.651-1.434L8.831 5.896h-1.88z"/>
+        </svg>
+        <span class="social-share-name">Hacker News</span>
+    </a>
+    <a class="social-share-btn social-share-email"
+       href="{{ $mailHref }}"
+       aria-label="Share via Email"
+       title="Share via Email">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M1.5 4.5h21A1.5 1.5 0 0124 6v12a1.5 1.5 0 01-1.5 1.5h-21A1.5 1.5 0 010 18V6a1.5 1.5 0 011.5-1.5zm10.5 9.296L2.31 6.75h19.38L12 13.796zM9.74 12.43l-7.99 5.82h20.5l-7.99-5.82-2.26 1.643z"/>
+        </svg>
+        <span class="social-share-name">Email</span>
+    </a>
+    <button class="social-share-btn social-share-copy" type="button"
+            data-share-url="{{ $url }}"
+            aria-label="Copy link"
+            title="Copy link">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7a5 5 0 100 10h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4a5 5 0 000-10z"/>
+        </svg>
+        <span class="social-share-name">Copy link</span>
+    </button>
+</div>
+
+<script>
+(function(){
+    var btn = document.querySelector('.social-share-copy');
+    if (!btn) return;
+    btn.addEventListener('click', function(){
+        var url = btn.getAttribute('data-share-url');
+        var label = btn.querySelector('.social-share-name');
+        var original = label ? label.textContent : '';
+        var done = function(){
+            if (label) {
+                label.textContent = 'Copied!';
+                setTimeout(function(){ label.textContent = original; }, 1500);
+            }
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(url).then(done, done);
+        } else {
+            var ta = document.createElement('textarea');
+            ta.value = url;
+            ta.setAttribute('readonly', '');
+            ta.style.position = 'absolute';
+            ta.style.left = '-9999px';
+            document.body.appendChild(ta);
+            ta.select();
+            try { document.execCommand('copy'); } catch (e) {}
+            document.body.removeChild(ta);
+            done();
+        }
+    });
+})();
+</script>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -44,7 +44,9 @@
         </div>
         {{ end }}
     </article>
-    
+
+    {{ partial "social-share.html" . }}
+
     <div class="action-group">
         {{ if or .NextInSection .PrevInSection }}
             {{ if .PrevInSection }}

--- a/prompts/blog-voice.md
+++ b/prompts/blog-voice.md
@@ -1,0 +1,25 @@
+# Blog Voice — Experience Digest Editorial Posts
+
+## Persona
+
+Seasoned enterprise architect with 15+ years across Adobe Commerce (Magento), AEM, and the broader Adobe DX stack. Has run the platform operationally, reviewed vendor proposals, and sat in the post-incident calls. Understands the difference between what a CVE advisory says and what it means for a team actually running commerce infrastructure.
+
+## Voice
+
+- First-person editorial, not neutral summarizer
+- Technically precise without being a lecture
+- Draws implications that advisories don't — operational impact, deployment window risk, architectural exposure patterns
+- Skeptical of vendor framing when the real-world surface is bigger than stated
+- Short paragraphs; no throat-clearing; no hedging
+- Structured: setup → the specific thing → the pattern it reveals → the practical call
+
+## Audience
+
+Commerce architects, platform engineers, and technical leads who receive security bulletins but need someone to translate "what does this mean for how we run this" — not patch management novices, not C-suite summaries.
+
+## What Not To Do
+
+- Don't just summarize the advisory — everyone can read the CVE
+- Don't end with boilerplate "patch immediately" — if patching were straightforward, this editorial wouldn't need to exist
+- Don't soften real exposure with "may" and "could" when the technical read is clear
+- Don't ignore the supply-chain angle, the integration layer, or the deployment lag problem — those are where the actual risk lives in enterprise commerce

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1744,7 +1744,7 @@ body {
 .xd-logo svg {
     width: 32px;
     height: 32px;
-    fill: #f97316;
+    fill: #14b8a6;
 }
 
 .xd-logo-text {
@@ -1972,7 +1972,7 @@ body {
 }
 
 .card-title a:hover {
-    color: #f97316;
+    color: #14b8a6;
 }
 
 /* Content card styling */
@@ -1980,7 +1980,7 @@ body {
 .card-summary h2 {
     font-size: 0.95rem;
     font-weight: 600;
-    color: #f97316;
+    color: #14b8a6;
     margin: 1rem 0 0.5rem 0;
 }
 
@@ -1988,7 +1988,7 @@ body {
 .card-summary h3 {
     font-size: 0.875rem;
     font-weight: 600;
-    color: #fb923c;
+    color: #2dd4bf;
     margin: 0.75rem 0 0.5rem 0;
 }
 
@@ -2016,7 +2016,7 @@ body {
 .content-card li:hover,
 .card-summary li:hover {
     background: rgba(255, 255, 255, 0.05);
-    border-left-color: #ea580c;
+    border-left-color: #0d9488;
 }
 
 .content-card li strong,
@@ -2102,11 +2102,11 @@ body {
 }
 
 .xd-btn-accent {
-    background: #ea580c;
+    background: #0d9488;
 }
 
 .xd-btn-accent:hover {
-    background: #c2410c;
+    background: #0f766e;
 }
 
 /* Button aliases for backwards compatibility */
@@ -2131,11 +2131,11 @@ body {
 }
 
 .btn-primary {
-    background: #ea580c;
+    background: #0d9488;
 }
 
 .btn-primary:hover {
-    background: #c2410c;
+    background: #0f766e;
 }
 
 .btn-secondary {
@@ -2148,6 +2148,102 @@ body {
     background: #3e3e3e;
     border-color: #8e8e8e;
     color: #fff;
+}
+
+/* Social share */
+.social-share {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+    margin: 2.5rem 0 1rem;
+    padding: 1rem 1.25rem;
+    background: #1f1f1f;
+    border: 1px solid #3e3e3e;
+    border-radius: 6px;
+}
+
+.social-share-label {
+    font-weight: 600;
+    color: #d1d1d1;
+    margin-right: 0.25rem;
+}
+
+.social-share-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.75rem;
+    background: #2a2a2a;
+    color: #d1d1d1;
+    text-decoration: none;
+    border: 1px solid #3e3e3e;
+    border-radius: 4px;
+    font: inherit;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.social-share-btn svg {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+}
+
+.social-share-btn:hover {
+    color: #fff;
+    border-color: #8e8e8e;
+    background: #3e3e3e;
+}
+
+.social-share-linkedin:hover {
+    background: #0a66c2;
+    border-color: #0a66c2;
+    color: #fff;
+}
+
+.social-share-x:hover {
+    background: #000;
+    border-color: #000;
+    color: #fff;
+}
+
+.social-share-facebook:hover {
+    background: #1877f2;
+    border-color: #1877f2;
+    color: #fff;
+}
+
+.social-share-bluesky:hover {
+    background: #1185fe;
+    border-color: #1185fe;
+    color: #fff;
+}
+
+.social-share-reddit:hover {
+    background: #ff4500;
+    border-color: #ff4500;
+    color: #fff;
+}
+
+.social-share-hackernews:hover {
+    background: #ff6600;
+    border-color: #ff6600;
+    color: #fff;
+}
+
+@media (max-width: 600px) {
+    .social-share {
+        padding: 0.75rem;
+    }
+    .social-share-name {
+        display: none;
+    }
+    .social-share-btn {
+        padding: 0.5rem;
+    }
 }
 
 /* Subscribe Card */
@@ -2203,7 +2299,7 @@ body {
 
 .subscribe-button {
     padding: 0.625rem 1.25rem;
-    background: #ea580c;
+    background: #0d9488;
     color: white;
     border: none;
     border-radius: 4px;
@@ -2214,7 +2310,7 @@ body {
 }
 
 .subscribe-button:hover {
-    background: #c2410c;
+    background: #0f766e;
 }
 
 .subscribe-features {
@@ -2229,7 +2325,7 @@ body {
 
 .subscribe-features span::before {
     content: '✓';
-    color: #ea580c;
+    color: #2d9d78;
     margin-right: 0.5rem;
     font-weight: bold;
 }
@@ -2600,5 +2696,177 @@ body {
     
     .grid-cards {
         grid-template-columns: 1fr;
+    }
+}
+
+/* Blog post layout — main + sticky right rail */
+.blog-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 780px) 300px;
+    gap: 1.75rem;
+    align-items: start;
+    justify-content: center;
+}
+
+.blog-main {
+    min-width: 0;
+}
+
+.blog-sidebar {
+    position: sticky;
+    top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin-top: 2rem;
+}
+
+.blog-sidebar-block {
+    background: #1f1f1f;
+    border: 1px solid #3e3e3e;
+    border-radius: 6px;
+    padding: 1rem 1.25rem;
+}
+
+.blog-sidebar-title {
+    font-size: 0.75rem;
+    color: #14b8a6;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    margin: 0 0 0.75rem;
+}
+
+.blog-author {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+}
+
+.blog-author + .blog-author {
+    margin-top: 0.875rem;
+    padding-top: 0.875rem;
+    border-top: 1px solid #2e2e2e;
+}
+
+.blog-author-avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    object-fit: cover;
+}
+
+.blog-author-avatar-fallback {
+    background: linear-gradient(135deg, #14b8a6, #0d9488);
+    color: #f5f5f5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 1.125rem;
+    text-transform: uppercase;
+}
+
+.blog-author-text {
+    min-width: 0;
+}
+
+.blog-author-name {
+    color: #f5f5f5;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.9375rem;
+    display: block;
+    line-height: 1.2;
+}
+
+a.blog-author-name:hover {
+    color: #14b8a6;
+}
+
+.blog-author-title {
+    color: #aaa;
+    font-size: 0.8125rem;
+    margin-top: 0.15rem;
+    line-height: 1.3;
+}
+
+.blog-author-bio {
+    color: #888;
+    font-size: 0.8125rem;
+    margin: 0.5rem 0 0;
+    line-height: 1.45;
+}
+
+.blog-toc nav > ul,
+.blog-toc ul {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+}
+
+.blog-toc ul ul {
+    padding-left: 0.875rem;
+    margin-top: 0.25rem;
+    border-left: 1px solid #3e3e3e;
+}
+
+.blog-toc li {
+    margin: 0.3rem 0;
+    line-height: 1.4;
+}
+
+.blog-toc a {
+    color: #d1d1d1;
+    text-decoration: none;
+    font-size: 0.875rem;
+    display: block;
+    padding: 0.15rem 0 0.15rem 0.5rem;
+    border-left: 2px solid transparent;
+    transition: color 0.1s ease, border-color 0.1s ease;
+}
+
+.blog-toc a:hover {
+    color: #14b8a6;
+    border-left-color: #14b8a6;
+}
+
+.blog-related-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.blog-related-list li {
+    margin: 0.5rem 0;
+    line-height: 1.35;
+}
+
+.blog-related-list a {
+    color: #d1d1d1;
+    text-decoration: none;
+    font-size: 0.875rem;
+    display: block;
+}
+
+.blog-related-list a:hover {
+    color: #14b8a6;
+}
+
+.blog-related-date {
+    display: block;
+    font-size: 0.75rem;
+    color: #888;
+    margin-top: 0.15rem;
+}
+
+@media (max-width: 1024px) {
+    .blog-layout {
+        grid-template-columns: 1fr;
+    }
+    .blog-sidebar {
+        position: static;
+        order: 2;
     }
 }


### PR DESCRIPTION
## Summary
- Adds `/blog` section for editorial commentary, separate from the auto-scraped bulletin stream
- Inaugural post: "Three Signals from November" — editorial synthesis of Xurum campaign + CVE-2025-54236 + CVE-2025-64174
- Blog posts publish via `/blog/feed.xml`; micro.blog subscribes separately from the root bulletin feed (mirrors doughatcher.com pattern)

## Changes
- `content/blog/_index.md` — section root
- `layouts/blog/single.html` + `list.html` — adapted to experience-digest xd-* CSS style
- `archetypes/blog.md` — correct frontmatter for new editorial posts
- Blog nav link in `baseof.html` (all pages) and `index.html` (homepage)
- Homepage blog callout section showing latest 3 posts
- `.github/workflows/blog-publish.yml` — triggers deploy on `content/blog/**` push
- `.gitignore`: `content/*` + `!content/blog/` (mirrors doughatcher.com)
- Fix pre-existing `match` → `like` operator bug in index.html hero section

## Test plan
- [ ] `/blog/` list renders with inaugural post
- [ ] `/blog/feed.xml` valid RSS
- [ ] Blog nav link visible on all pages
- [ ] Blog callout on homepage
- [ ] Single post renders correctly with breadcrumb + reading time + tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)