### PR TITLE
Fix blog 404 + trigger Micro.blog on content + rename adobedigest→experiencedigest

### DIFF
--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,5 +1,5 @@
 ---
 title: "Blog"
 description: "Editorial coverage of the security landscape for Adobe Commerce and Magento — the context, correlation, and preemptive takes that the automated bulletins cannot provide."
-type: blog
+layout: "list"
 ---


### PR DESCRIPTION
Three small changes that go together.

## Summary
- **Fix `/blog/<slug>/` 404 on Micro.blog.** Drop \`type: blog\` from \`content/blog/_index.md\`. Micro.blog's hosted Hugo was serving the section list and emitting links from the homepage callout, but returning 404 for every individual \`/blog/<slug>/\` URL. Comparing to working sections (products here, blog on doughatcher.com) the explicit \`type:\` was the only differentiator. Layout resolution still finds \`layouts/blog/single.html\` by section name.
- **Wire \`content/blog/**\` into deploy.yml paths.** The previous filter only watched theme files (layouts/static/data/config.json/theme.toml), so content edits would only trip blog-publish.yml (GitHub Pages) and leave Micro.blog stale. Scraper "Update scraped post IDs [skip ci]" commits stay skipped.
- **Rename Adobe Digest → Experience Digest in docs, scraper, CI.** Updates project name in README, devcontainer, GitHub agent persona, docs/, scraper/, deploy summaries, justfile. Rewrites the public domain from adobedigest.com (now DNS-dead) to experiencedigest.org. Preserves \`adobedigest.micro.blog\` (still the Micro.blog account address + Micropub destination UID; only the public domain and theme name changed).

## Test plan
- [x] Local Hugo serves both posts at \`/blog/<slug>/\`
- [ ] After merge: deploy.yml fires (matches new \`content/blog/**\` path) → theme 102162 reloaded
- [ ] After merge: https://experiencedigest.org/blog/2026-05-23-composer-perforce-command-injection/ returns 200
- [ ] After merge: https://experiencedigest.org/blog/2025-11-26-three-signals-from-november/ returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)