### PR TITLE
Move author definitions from data/ to config.json params.authors

### DIFF
--- a/config.json
+++ b/config.json
@@ -115,6 +115,14 @@
         "url": "[ACTIVITYPUB_ACTOR]"
       }
     },
+    "authors": {
+      "doug-hatcher": {
+        "name": "Doug Hatcher",
+        "title": "Enterprise Architect at Blue Acorn iCI",
+        "url": "https://doughatcher.com",
+        "avatar": "https://avatars.micro.blog/avatars/2025/42/1836278.jpg"
+      }
+    },
     "description": "An independent community digest tracking security bulletins, CVEs, and research for Adobe Commerce and Experience Manager. Community-maintained, not affiliated with Adobe.",
     "about_me": "Enterprise architecture and tech junkie",
     "bio": "Enterprise architecture and tech junkie",

--- a/data/authors/doug-hatcher.yaml
+++ b/data/authors/doug-hatcher.yaml
@@ -1,3 +1,0 @@
-name: Doug Hatcher
-title: Enterprise Architect at Blue Acorn iCI
-url: https://doughatcher.com

--- a/layouts/partials/blog-sidebar.html
+++ b/layouts/partials/blog-sidebar.html
@@ -16,11 +16,12 @@
 {{ if or $authorSlugs $hasToc $related }}
 <aside class="blog-sidebar">
 
-    {{/* `$.Site.Data.authors` can be nil on hosts that don't sync data/ in their
-         theme reload (Micro.blog has been observed to skip it). Default to an
-         empty dict so the lookup degrades to "no author block" rather than
-         crashing the build. */}}
-    {{ $authorsData := $.Site.Data.authors | default dict }}
+    {{/* Author definitions live under `params.authors` in config.json. Earlier
+         attempt used `data/authors/*.yaml` but Micro.blog's theme reload
+         skips data/ subdirs, so the lookup came up nil on prod. config.json
+         is always synced, so params is the reliable home. Still defaulting
+         to an empty dict so a missing `authors` map degrades gracefully. */}}
+    {{ $authorsData := $.Site.Params.authors | default dict }}
     {{ if $authorSlugs }}
     <div class="blog-sidebar-block blog-author-block">
         <h3 class="blog-sidebar-title">{{ if gt (len $authorSlugs) 1 }}Authors{{ else }}Author{{ end }}</h3>


### PR DESCRIPTION
## Summary
- Confirms on prod (via PR #16's empty author block) that Micro.blog's theme reload skips \`data/\` subdirs. \`config.json\` IS reliably synced, so author definitions move into \`params.authors\`.
- Adds \`params.authors.doug-hatcher\` to config.json with name, title, url, avatar.
- Switches \`layouts/partials/blog-sidebar.html\` to read \`$.Site.Params.authors\` (still defaulted to empty dict for graceful degradation).
- Removes \`data/authors/doug-hatcher.yaml\` (superseded).

Same \`author: <slug>\` / \`authors: [<slug>, ...]\` post frontmatter contract — adding a new contributor is still one entry in the map.

## Test plan
- [x] Local Hugo renders Doug Hatcher byline + avatar from params.authors
- [ ] After merge + deploy, author block populated on https://experiencedigest.org/blog/2026-05-23-composer-perforce-command-injection/
- [ ] After merge + deploy, same on /blog/2025-11-26-three-signals-from-november/

🤖 Generated with [Claude Code](https://claude.com/claude-code)