### PR TITLE
Credit Packagist's writeup + add blog.packagist.com to scraper sources

### DIFF
--- a/content/blog/2026-05-23-composer-perforce-command-injection.md
+++ b/content/blog/2026-05-23-composer-perforce-command-injection.md
@@ -6,9 +6,15 @@ author: doug-hatcher
 tags: [composer, php, supply-chain, cve, magento, adobe-commerce, dependency-management]
 category: "Attack Analysis"
 summary: "Two command injection vulnerabilities in Composer's Perforce driver are exploitable even if you've never touched Perforce. For Magento shops running dev dependencies from source, CVE-2026-40261 is a supply-chain exposure hiding behind a feature most teams don't know is active."
+related:
+  - title: "Composer 2.9.6: Perforce driver command injection vulnerabilities"
+    url: https://blog.packagist.com/composer-2-9-6-perforce-driver-command-injection-vulnerabilities/
+    date: "May 21, 2026"
 ---
 
 Update Composer to 2.9.6 or 2.2.27 LTS now. If that sentence is enough, you're done. If you want to understand why this one is worth a closer look, keep reading.
+
+Background: the Composer maintainers published [their own writeup of these advisories](https://blog.packagist.com/composer-2-9-6-perforce-driver-command-injection-vulnerabilities/) on the Packagist blog. The technical details and the registry-level mitigations described below come from that post; this piece is the operator's read for commerce teams.
 
 ## Quick Refresher: Composer, Drivers, and Why Perforce Is in There
 

--- a/data/sources.yaml
+++ b/data/sources.yaml
@@ -62,6 +62,19 @@ sources:
       - news
       - akamai
   
+  # Packagist Blog (Composer maintainers' announcements — releases, security advisories,
+  # ecosystem changes that affect every PHP/Magento composer install)
+  - type: atom-feed
+    name: packagist-blog
+    display_name: Packagist Blog
+    description: Composer and Packagist announcements, including security advisories that affect every PHP/Magento dependency pipeline
+    url: https://blog.packagist.com/feed/
+    limit: 30
+    categories:
+      - news
+      - composer
+      - supply-chain
+
   # NIST NVD CVE Database (filtered for Adobe Commerce/Magento/AEM)
   - type: nist-nvd
     name: nist-nvd


### PR DESCRIPTION
## Summary
Two related fixes after reader feedback:

1. **Cite the Packagist source in the Composer/Perforce post.** Adds a background paragraph at the top of \`content/blog/2026-05-23-composer-perforce-command-injection.md\` linking to [Packagist's own writeup](https://blog.packagist.com/composer-2-9-6-perforce-driver-command-injection-vulnerabilities/) — that's where the technical details and registry-level mitigations originated. The current post is the operator-side read on top of that.

2. **Add blog.packagist.com to the scraper.** Confirmed RSS feed at \`https://blog.packagist.com/feed/\` returns valid XML. Adding as a new \`atom-feed\` source means future Composer/Packagist announcements auto-populate the bulletin queue rather than waiting for manual editorial discovery. Categories: \`news\`, \`composer\`, \`supply-chain\`.

3. Also adds the Packagist post to the article's \`related:\` frontmatter so it surfaces in the right-rail sidebar block.

## Test plan
- [ ] After merge + deploy, the Composer/Perforce post shows the background citation paragraph at the top
- [ ] Sidebar "Related coverage" block on that post includes the Packagist link
- [ ] Next scraper run pulls items from blog.packagist.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)