### PR TITLE
Fix PR screenshot check body quoting

### DIFF
--- a/.github/workflows/pr-screenshot-check.yml
+++ b/.github/workflows/pr-screenshot-check.yml
@@ -52,9 +52,9 @@ jobs:
       - name: Check for screenshots in PR description or committed to branch
         if: steps.check-template-changes.outputs.template_changed == 'true'
         id: check-screenshots
+        env:
+          PR_BODY: ${{ steps.pr-body.outputs.result }}
         run: |
-          PR_BODY="${{ steps.pr-body.outputs.result }}"
-
           # Count image references in PR body
           DESKTOP_COUNT=$(echo "$PR_BODY" | grep -iE "(desktop.*screenshot|screenshot.*desktop|!\[.*desktop)" | wc -l)
           TABLET_COUNT=$(echo "$PR_BODY" | grep -iE "(tablet.*screenshot|screenshot.*tablet|ipad.*pro|!\[.*tablet)" | wc -l)


### PR DESCRIPTION
## Summary
- pass the PR body to the screenshot-check shell step through an environment variable
- avoid interpolating multiline Markdown directly into the generated shell script

## Why
The latest failed PR Screenshot Verification run tried to execute Markdown from the PR body as shell () before it could report missing screenshots.