### PR TITLE
Add micro.blog conversation widget to single posts

### DIFF
--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -47,6 +47,11 @@
 
     {{ partial "social-share.html" . }}
 
+    <!-- Micro.blog Conversation Thread —
+         pulls in any micro.blog replies/likes for this URL. Same widget
+         doughatcher.com uses on its single-post template. -->
+    <script type="text/javascript" src="https://micro.blog/conversation.js?url={{ .Permalink }}"></script>
+
     <div class="action-group">
         {{ if or .NextInSection .PrevInSection }}
             {{ if .PrevInSection }}


### PR DESCRIPTION
## Summary

Renders any micro.blog replies and likes inline on single posts via the standard `conversation.js` embed — same widget doughatcher.com uses on `layouts/post/single.html`. Placed between the social-share strip and the prev/next/home action-group.

## Files

- `layouts/post/single.html` — one-line addition of the script tag with `{{ .Permalink }}`

## Why

Doug asked to bring the comment functionality from doughatcher.com over to experience-digest so the two sites have parity on reader interaction.

## Test plan

- [ ] Open any post on experiencedigest.org after merge → conversation widget renders below the share strip (empty box if no replies yet, populated if any exist)
- [ ] Reply to a post via micro.blog → reply appears in the widget on next page load
- [ ] Confirm widget does not appear on list/category/home pages — only single posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)