### PR TITLE
Fix missing Akamai link in November signals post

### DIFF
--- a/content/blog/2025-11-26-three-signals-from-november.md
+++ b/content/blog/2025-11-26-three-signals-from-november.md
@@ -27,7 +27,7 @@ The [Xurum webshell campaign](https://www.akamai.com/blog/security-research/new-
 1. A meaningful percentage of Magento installs are still unpatched against a well-documented attack chain.
 2. The attacker tooling has matured — Xurum has environment-awareness that older skimmer campaigns lacked.
 
-The practical read for commerce ops teams: if you're running a Magento instance and haven't validated your patching posture against Akamai's published indicators, do that before reading the rest of this.
+The practical read for commerce ops teams: if you're running a Magento instance and haven't validated your patching posture against [Akamai's published indicators](https://www.akamai.com/blog/security-research/new-sophisticated-magento-campaign-xurum-webshell), do that before reading the rest of this.
 
 ## The Risk That Patch Notes Don't Quantify: CVE-2025-54236
 


### PR DESCRIPTION
## Summary

One-line fix from Sloane's editorial pass. Line 30 of the November signals piece references "Akamai's published indicators" but had no anchor — the Xurum research blog is already linked five lines up (line 25), so this just surfaces the same URL where the reader actually needs it.

## Change

```diff
- ...validated your patching posture against Akamai's published indicators...
+ ...validated your patching posture against [Akamai's published indicators](https://www.akamai.com/blog/security-research/new-sophisticated-magento-campaign-xurum-webshell)...
```

## Test plan

- [ ] After merge, open `/blog/2025/11/three-signals-from-november/` (or equivalent URL) and verify the link renders on line 30
- [ ] Click through to confirm the destination resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)