### PR TITLE
Thread --timeout through microblog deploy poll loop

### DIFF
--- a/.github/deploy/microblog_deploy.py
+++ b/.github/deploy/microblog_deploy.py
@@ -258,7 +258,7 @@ class MicroblogDeployer:
         
         return False
     
-    def deploy(self, reload=True, rebuild=True, monitor=True):
+    def deploy(self, reload=True, rebuild=True, monitor=True, monitor_timeout=60):
         """Execute deployment sequence"""
         print("🚀 Micro.blog Deployment")
         print("=" * 60)
@@ -288,7 +288,7 @@ class MicroblogDeployer:
         # Monitor build by polling check endpoint
         if monitor and rebuild:
             print()
-            if not self.poll_check_endpoint():
+            if not self.poll_check_endpoint(timeout=monitor_timeout):
                 success = False
         
         print()
@@ -333,12 +333,13 @@ def main():
             sys.exit(0 if success else 1)
         
         if args.all:
-            success = deployer.deploy(reload=True, rebuild=True, monitor=True)
+            success = deployer.deploy(reload=True, rebuild=True, monitor=True, monitor_timeout=args.timeout)
         else:
             success = deployer.deploy(
                 reload=args.reload,
                 rebuild=args.rebuild,
-                monitor=args.monitor
+                monitor=args.monitor,
+                monitor_timeout=args.timeout,
             )
         
         sys.exit(0 if success else 1)


### PR DESCRIPTION
## Summary

- Every recent \"Deploy to Micro.blog\" run (all 5 most-recent runs on `main`) has ended in failure with the same tail: `Timeout reached (60s) after 12 polls` in `poll_check_endpoint`, then exit 1.
- Root cause is a plumbing bug, not a real deploy failure. `deploy.yml` calls the script with `--all --timeout 120`, but `deploy()` (line 261) never accepted a `timeout` kwarg, so the `--all` code path called `poll_check_endpoint()` with its default 60s regardless. The CLI flag was silently ignored.
- Fix: add a `monitor_timeout` kwarg to `deploy()`, pass `args.timeout` in from `main()`, and hand it to `poll_check_endpoint(timeout=...)`. No workflow changes needed — the workflow already passes `--timeout 120`.
- Detected by the nightly GH failure sweep (Hobbs).

## Test plan

- [ ] After merge, watch the next scheduled `Deploy to Micro.blog` run.
- [ ] Confirm the log shows `(Timeout: 120s, interval: 5s)` instead of `60s`.
- [ ] Confirm the run finishes green (or, if it still fails, that the tail is a different, real error).